### PR TITLE
Fix casper when used with -c

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -26,6 +26,11 @@ var buildCmd = &cobra.Command{
 			return errFormat
 		}
 
+		// fix the template path if it is from the config file
+		if viper.InConfig("template") && !cmd.Flag("template").Changed {
+			template = configPath(cfgFile, template)
+		}
+
 		return buildRun(template, sourcesList)
 	},
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -35,6 +35,11 @@ var diffCmd = &cobra.Command{
 			return err
 		}
 
+		// fix the template path if it is from the config file
+		if viper.InConfig("template") && !cmd.Flag("template").Changed {
+			template = configPath(cfgFile, template)
+		}
+
 		return diffRun(template, format, key, sourcesList, storage, config, !plain)
 	},
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -43,6 +43,11 @@ var pushCmd = &cobra.Command{
 			return err
 		}
 
+		// fix the template path if it is from the config file
+		if viper.InConfig("template") && !cmd.Flag("template").Changed {
+			template = configPath(cfgFile, template)
+		}
+
 		return pushRun(template, format, key, sourcesList, storage, config, force, !plain)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -63,4 +64,19 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		fmt.Println("Error parsing config file:", err)
 	}
+}
+
+// configPath returns absolute path for paths that are relative to the config
+func configPath(cfgPath, p string) string {
+	if cfgPath == "" {
+		// congig is in current dir
+		return p
+	}
+
+	absCfgPath, err := filepath.Abs(cfgPath)
+	if err != nil {
+		return p
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(absCfgPath), p))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,9 +53,10 @@ func init() {
 func initConfig() {
 	if cfgFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(cfgFile)
+	} else {
+		viper.AddConfigPath(".")
 	}
 
-	viper.AddConfigPath(".")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// Read config file

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestConfigPath(t *testing.T) {
+	currDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir("/"); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		cfg string
+		p   string
+		res string
+	}{
+		{"", "./example", "./example"},
+		{"./config/file", "./example", "/config/example"},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Case%v", i), func(t *testing.T) {
+			res := configPath(tc.cfg, tc.p)
+
+			if res != tc.res {
+				t.Errorf("Got %v; want %v", res, tc.res)
+			}
+		})
+	}
+
+	if err := os.Chdir(currDir); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/sources.go
+++ b/cmd/sources.go
@@ -91,7 +91,7 @@ func getFileSource(cfg map[string]interface{}) (*source.Source, error) {
 		format = formatI.(string)
 	}
 
-	r, err := os.Open(path)
+	r, err := os.Open(configPath(cfgFile, path))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes the working directory to the location of the config file so all
relative paths relative to the config file will work properly.