### PR TITLE
Allow duplicate keys in sources

### DIFF
--- a/source/multi.go
+++ b/source/multi.go
@@ -1,6 +1,8 @@
 package source
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // NewMultiSourcer create source that is a collection of value sources.
 func NewMultiSourcer(vss ...Getter) (*Source, error) {
@@ -8,8 +10,18 @@ func NewMultiSourcer(vss ...Getter) (*Source, error) {
 
 	for _, s := range vss {
 		for k, v := range s.Get() {
-			if _, ok := vars[k]; ok {
-				return nil, fmt.Errorf("duplicated key '%v'", k)
+			if prev, ok := vars[k]; ok {
+				switch p := prev.(type) {
+				case interface{}:
+					vars[k] = []interface{}{p, v}
+				case []interface{}:
+					vars[k] = append(p, v)
+				default:
+					return nil, fmt.Errorf("multy sources merging failed")
+				}
+
+				continue
+
 			}
 			vars[k] = v
 		}

--- a/source/multi_test.go
+++ b/source/multi_test.go
@@ -56,8 +56,14 @@ func TestMultiSourcer(t *testing.T) {
 					"key1": "var3",
 				}),
 			},
-			nil,
-			false,
+			map[string]interface{}{
+				"key1": []interface{}{
+					"var1",
+					"var3",
+				},
+				"key2": "var2",
+			},
+			true,
 		},
 	}
 


### PR DESCRIPTION
When same key appear multiple times in sources, casper will merge them
in array. That way you can construct arrays in the command line.